### PR TITLE
chore: Update workflow to use --immutable option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
             {{ runner.os }}-Node-v${{ matrix.node-version }}-Yarn-
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable


### PR DESCRIPTION
## Description

워크플로우에서 lock 파일을 기준으로 패키지를 설치하기 위해 `--immutable` option을 추가함.